### PR TITLE
Update recipe for py313_codesign

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mmh3" %}
-{% set version = "4.1.0" %}
+{% set version = "5.0.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/hajimes/{{ name|lower }}/archive/v{{ version }}.tar.gz
-  sha256: 0b476dd6f83172cfb3bfec534e78011d9d86efe803182f1932b3566fb9128659
+  sha256: 17cc47eb3cb77da32856d0a6c10cb9e463574e4a769cc81a6ec4a3e35b45d23a
 
 build:
-  number: 1
+  number: 0
   skip: True # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-build-isolation --no-cache-dir -vvv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 0b476dd6f83172cfb3bfec534e78011d9d86efe803182f1932b3566fb9128659
 
 build:
-  number: 0
+  number: 1
   skip: True # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-build-isolation --no-cache-dir -vvv
 


### PR DESCRIPTION
Rebuild for codesigned win-64 py313 artifacts.

update to 5.0.1
https://github.com/hajimes/mmh3/tree/v5.0.1